### PR TITLE
package_manager: don't provide multiple args to shell=True

### DIFF
--- a/package_manager.py
+++ b/package_manager.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 
 def _command_exists(cmd: str) -> bool:
-    ret = subprocess.run(["command", "-v", cmd], stdout=subprocess.DEVNULL,
+    ret = subprocess.run(f"command -v {cmd}", stdout=subprocess.DEVNULL,
                          stderr=subprocess.DEVNULL, shell=True)
     return ret.returncode == 0
 


### PR DESCRIPTION
This can apparently result in false positive 0 exit codes.